### PR TITLE
fix: change index.ts template for export generated property

### DIFF
--- a/src/buildUtil/index-template.template
+++ b/src/buildUtil/index-template.template
@@ -2,8 +2,8 @@
 import {{key}} from "{{path}}";
 {{/each}}
 
-let __VERSION__ = "{{version}}";
-let __NAME__ = "{{name}}";
+export const __VERSION__ = "{{version}}";
+export const __NAME__ = "{{name}}";
 
 import __MAIN__ from "{{mainPath}}";
 


### PR DESCRIPTION
change `index.ts` template for **export constants __NAME__ and __VERSION__**  .
those generated constants have not been exported so far.
However, it should be exported naturally.

```ts
import {__NAME__, __VERSION__} from "./index";

console.log(`this plugin is ${__NAME__}. version: ${__VERIOSN__}`)
```